### PR TITLE
fix: Ensure .env is loaded before module imports

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,10 @@
 import os
 import logging
 from dotenv import load_dotenv
+
+# Загружаем переменные окружения в первую очередь!
+load_dotenv()
+
 from telegram import ReplyKeyboardMarkup, ReplyKeyboardRemove, Update
 from telegram.ext import (
     Application,
@@ -13,9 +17,6 @@ from telegram.ext import (
 from notion_handler import create_notion_page, create_link_page
 from transcriber import transcribe_voice
 from url_processor import process_url
-
-# Загрузка переменных окружения
-load_dotenv()
 
 # Настройка логирования
 logging.basicConfig(


### PR DESCRIPTION
This commit moves the `load_dotenv()` call to the top of `bot.py`, before other project-specific modules (`notion_handler`, `transcriber`, `url_processor`) are imported.

This resolves a bug where modules would fail to see the environment variables (like `OPENAI_API_KEY`) because they were being imported before `load_dotenv()` had a chance to run. This ensures that the environment is correctly configured before any part of the application that depends on it is loaded.