### PR TITLE
Define conversation states and handlers

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -29,6 +29,10 @@ logger = logging.getLogger(__name__)
 
 
 
+# === Константы состояний ===
+# ConversationHandler использует числовые идентификаторы для обозначения этапов диалога.
+CHOOSING_ACTION, AWAITING_INPUT, AWAITING_LINK, SELECTING_TASK_PROPERTY = range(4)
+
 # === Клавиатуры ===
 main_keyboard = [["Идея", "Задача", "Ссылка"]]
 main_markup = ReplyKeyboardMarkup(main_keyboard, one_time_keyboard=True, resize_keyboard=True)
@@ -222,7 +226,18 @@ def main() -> None:
     conv_handler = ConversationHandler(
         entry_points=[CommandHandler("start", start)],
         states={
-
+            CHOOSING_ACTION: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, choice_action)
+            ],
+            AWAITING_INPUT: [
+                MessageHandler((filters.TEXT & ~filters.COMMAND) | filters.VOICE, received_input)
+            ],
+            AWAITING_LINK: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, received_link)
+            ],
+            SELECTING_TASK_PROPERTY: [
+                CallbackQueryHandler(received_task_property, pattern=r"^taskprop_")
+            ],
         },
         fallbacks=[CommandHandler("cancel", cancel)],
     )


### PR DESCRIPTION
## Summary
- add explicit state constants for the Telegram bot conversation flow
- wire ConversationHandler state mappings for action choice, input/link processing, and task property selection

## Testing
- `python -m py_compile bot.py`
- `python -m py_compile notion_handler.py transcriber.py url_processor.py` *(fails: SyntaxError: unmatched '}' in notion_handler.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e9c9594832aa5d38dd1e130645f